### PR TITLE
deviseの設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ ruby '3.2.1'
 gem 'rails', '~> 6.1.7', '>= 6.1.7.3'
 gem 'bootstrap', '~> 4.6.0'
 gem 'devise'
+gem 'devise-i18n'
+gem 'devise-i18n-views'
 # Use postgresql as the database for Active Record
 gem 'pg', '~> 1.1'
 # Use Puma as the app server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,9 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise-i18n (1.11.0)
+      devise (>= 4.9.0)
+    devise-i18n-views (0.3.7)
     erubi (1.12.0)
     execjs (2.8.1)
     ffi (1.15.5)
@@ -243,6 +246,8 @@ DEPENDENCIES
   bootstrap (~> 4.6.0)
   byebug
   devise
+  devise-i18n
+  devise-i18n-views
   jbuilder (~> 2.7)
   listen (~> 3.3)
   pg (~> 1.1)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,19 @@
 class ApplicationController < ActionController::Base
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  private
+  
+  def configure_permitted_parameters
+    added_attrs = [ :name,
+                    :email,
+                    :gender,
+                    :age,
+                    :address,
+                    :phone_number,
+                    :emergency_phone_number,
+                    :password
+                    ]
+    devise_parameter_sanitizer.permit :sign_up, keys: added_attrs
+    devise_parameter_sanitizer.permit :account_update, keys: added_attrs
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,7 @@ module Kintai
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
+    config.i18n.default_locale = :ja
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -46,7 +46,7 @@ Devise.setup do |config|
   # session. If you need permissions, you should implement that in a before filter.
   # You can also supply a hash where the value is a boolean determining whether
   # or not authentication should be aborted when the value is not present.
-  # config.authentication_keys = [:email]
+  # config.authentication_keys = [:id]
 
   # Configure parameters from the request object used for authentication. Each entry
   # given should be a request method and it will automatically be passed to the
@@ -244,7 +244,7 @@ Devise.setup do |config|
   # Turn scoped views on. Before rendering "sessions/new", it will first check for
   # "users/sessions/new". It's turned off by default because it's slower if you
   # are using only default views.
-  # config.scoped_views = false
+  # config.scoped_views = true
 
   # Configure the default scope given to Warden. By default it's the first
   # devise role declared in your routes (usually :user).
@@ -252,7 +252,7 @@ Devise.setup do |config|
 
   # Set this configuration to false if you want /users/sign_out to sign out
   # only the current scope. By default, Devise signs out all scopes.
-  # config.sign_out_all_scopes = true
+  # config.sign_out_all_scopes = false
 
   # ==> Navigation configuration
   # Lists the formats that should be treated as navigational. Formats like

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -1,0 +1,74 @@
+ja:
+  activerecord:
+    attributes:
+      employee:
+        current_password: "現在のパスワード"
+        email: "メールアドレス"
+        password: "パスワード"
+        password_confirmation: "確認用パスワード"
+        remember_me: "ログインを記憶"
+      admin:
+        current_password: "現在のパスワード"
+        email: "メールアドレス"
+        password: "パスワード"
+        password_confirmation: "確認用パスワード"
+        remember_me: "ログインを記憶"
+    models:
+      employee: "従業員"
+      admin: "管理者"
+  devise:
+    confirmations:
+      new:
+        resend_confirmation_instructions: "アカウント確認メール再送"
+    mailer:
+      confirmation_instructions:
+        action: "アカウント確認"
+        greeting: "ようこそ、%{recipient}さん!"
+        instruction: "次のリンクでメールアドレスの確認が完了します:"
+      reset_password_instructions:
+        action: "パスワード変更"
+        greeting: "こんにちは、%{recipient}さん!"
+        instruction: "誰かがパスワードの再設定を希望しました。次のリンクでパスワードの再設定が出来ます。"
+        instruction_2: "あなたが希望したのではないのなら、このメールは無視してください。"
+        instruction_3: "上のリンクにアクセスして新しいパスワードを設定するまで、パスワードは変更されません。"
+      unlock_instructions:
+        action: "アカウントのロック解除"
+        greeting: "こんにちは、%{recipient}さん!"
+        instruction: "アカウントのロックを解除するには下のリンクをクリックしてください。"
+        message: "ログイン失敗が繰り返されたため、アカウントはロックされています。"
+    passwords:
+      edit:
+        change_my_password: "パスワードを変更する"
+        change_your_password: "パスワードを変更"
+        confirm_new_password: "確認用新しいパスワード"
+        new_password: "新しいパスワード"
+      new:
+        forgot_your_password: "パスワードを忘れましたか?"
+        send_me_reset_password_instructions: "パスワードの再設定方法を送信する"
+    registrations:
+      edit:
+        are_you_sure: "本当に良いですか?"
+        cancel_my_account: "アカウント削除"
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: "空欄のままなら変更しません"
+        title: "%{resource}編集"
+        unhappy: "気に入りません"
+        update: "更新"
+        we_need_your_current_password_to_confirm_your_changes: "変更を反映するには現在のパスワードを入力してください"
+      new:
+        sign_up: "アカウント登録"
+    sessions:
+      new:
+        sign_in: "ログイン"
+    shared:
+      links:
+        back: "戻る"
+        didn_t_receive_confirmation_instructions: "アカウント確認のメールを受け取っていませんか?"
+        didn_t_receive_unlock_instructions: "アカウントの凍結解除方法のメールを受け取っていませんか?"
+        forgot_your_password: "パスワードを忘れましたか?"
+        sign_in: "ログイン"
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: "アカウント登録"
+    unlocks:
+      new:
+        resend_unlock_instructions: "アカウントの凍結解除方法を再送する"

--- a/config/locales/models.ja.yml
+++ b/config/locales/models.ja.yml
@@ -1,0 +1,11 @@
+ja:
+  activerecord:
+    attributes:
+      employee: #これがmodel
+        name: "名前"
+        gender: "性別"
+        address: "住所"
+        phone_number: "電話番号"
+        emergency_phone_number: "緊急連絡先"
+      admin:
+        name: "名前"


### PR DESCRIPTION
## このプルリクエストで何をしたのか
deviseを複数モデルで使用するための設定
deviseに登録するカラムの追加
ログイン時に求められる項目の設定

## 対象issue
- 作業したissueのURLをここに貼ること

## 重点的に見てほしいところ(不安なところ)
モデルの日本語化も設定していますが、viewの編集ができていないため、実際にできているか確かめられておりません。

## 実装できなくて後回しにしたところ
上記にもありますように、viewの編集がまだできておりません。

## 解決できなかったrubocop指摘
特にありません。

## チェックリスト
- [ ] 動作確認は実行した?
admin,employeeともにsign_inなど各ページの日本語表示を確認しました。

## その他参考情報
- 実装する上で参考にしたサイトなどがあればリンクをここに貼ること
https://qiita.com/ryuuuuuuuuuu/items/48dec280cf8925968c65
deviseの設定はnotionのページを参照