### PR TITLE
通知一覧の未読・既読のみの表示設定

### DIFF
--- a/app/controllers/admin/notifications_controller.rb
+++ b/app/controllers/admin/notifications_controller.rb
@@ -2,13 +2,10 @@ class Admin::NotificationsController < ApplicationController
   before_action :authenticate_admin!
 
   def index
-    if params[:read] == "true"
-      @notifications = Notification.where(kind: ["application", "approval_pending", "unapplied"]).where(read: true).by_recently_created.page(params[:page]).per(10)
-    elsif params[:read] == "false"
-      @notifications = Notification.where(kind: ["application", "approval_pending", "unapplied"]).where(read: false).by_recently_created.page(params[:page]).per(10)
-    else
-      @notifications = Notification.where(kind: ["application", "approval_pending", "unapplied"]).by_recently_created.page(params[:page]).per(10)
-    end
+    notifications = Notification.where(kind: ["application", "approval_pending", "unapplied"])
+    notifications = notifications.where(read: true) if params[:read] == "true"
+    notifications = notifications.where(read: false) if params[:read] == "false"
+    @notifications = notifications.by_recently_created.page(params[:page]).per(10)
   end
 
   def update

--- a/app/controllers/admin/notifications_controller.rb
+++ b/app/controllers/admin/notifications_controller.rb
@@ -2,7 +2,13 @@ class Admin::NotificationsController < ApplicationController
   before_action :authenticate_admin!
 
   def index
-    @notifications = Notification.all.by_recently_created
+    if params[:read] == "true"
+      @notifications = Notification.where(read: true).by_recently_created
+    elsif params[:read] == "false"
+      @notifications = Notification.where(read: false).by_recently_created
+    else
+      @notifications = Notification.all.by_recently_created
+    end
   end
 
   def update

--- a/app/controllers/employee/notifications_controller.rb
+++ b/app/controllers/employee/notifications_controller.rb
@@ -2,7 +2,13 @@ class Employee::NotificationsController < ApplicationController
   before_action :authenticate_employee!
 
   def index
-    @notifications = current_employee.notifications.by_recently_created
+    if params[:read] == "true"
+      @notifications = current_employee.notifications.where(read: true).by_recently_created
+    elsif params[:read] == "false"
+      @notifications = current_employee.notifications.where(read: false).by_recently_created
+    else
+      @notifications = current_employee.notifications.by_recently_created
+    end
   end
 
   def update

--- a/app/controllers/employee/notifications_controller.rb
+++ b/app/controllers/employee/notifications_controller.rb
@@ -2,13 +2,10 @@ class Employee::NotificationsController < ApplicationController
   before_action :authenticate_employee!
 
   def index
-    if params[:read] == "true"
-      @notifications = current_employee.notifications.where(kind: ["approval", "rejected", "unapplied"]).where(read: true).by_recently_created.page(params[:page]).per(10)
-    elsif params[:read] == "false"
-      @notifications = current_employee.notifications.where(kind: ["approval", "rejected", "unapplied"]).where(read: false).by_recently_created.page(params[:page]).per(10)
-    else
-      @notifications = current_employee.notifications.where(kind: ["approval", "rejected", "unapplied"]).by_recently_created.page(params[:page]).per(10)
-    end
+    notifications = current_employee.notifications.where(kind: ["approval", "rejected", "unapplied"])
+    notifications = notifications.where(read: true) if params[:read] == "true"
+    notifications = notifications.where(read: false) if params[:read] == "false"
+    @notifications = notifications.by_recently_created.page(params[:page]).per(10)
   end
 
   def update

--- a/app/views/admin/notifications/index.html.erb
+++ b/app/views/admin/notifications/index.html.erb
@@ -1,6 +1,9 @@
 <% provide(:title, "Notifications_Index") %>
 <div class="top">
   <h2>通知一覧</h2>
+  <%= link_to "未読のみ", admin_notifications_path(:read => "false") %>
+  <%= link_to "既読のみ", admin_notifications_path(:read => "true") %>
+  <%= link_to "全て", admin_notifications_path %>
   <% @notifications.each do |notification| %>
     <%= display_admin_notification(notification) %>
   <% end %>

--- a/app/views/employee/notifications/index.html.erb
+++ b/app/views/employee/notifications/index.html.erb
@@ -1,6 +1,9 @@
 <% provide(:title, "Notifications_Index") %>
 <div class="top">
   <h2>通知一覧</h2>
+  <%= link_to "未読のみ", employee_notifications_path(:read => "false") %>
+  <%= link_to "既読のみ", employee_notifications_path(:read => "true") %>
+  <%= link_to "全て", employee_notifications_path %>
   <% @notifications.each do |notification| %>
     <%= display_employee_notification(notification) %>
   <% end %>


### PR DESCRIPTION
## このプルリクエストで何をしたのか
・通知一覧で未読のみや既読のみを表示できるように設定

## 対象issue
- 作業したissueのURLをここに貼ること

## 重点的に見てほしいところ(不安なところ)
「未読のみ」などのリンクに`params`を含ませて、その取得によって表示を変えるという方法で実装しました。
全く同じようなことをしている記事を見つけられなかったので、いくつかの記事を参考して実装してみましたが、このやり方で問題ないのでしょうか？
もっといいやり方が他にあればご教授ください。

また、`params`に含ませるものを`:read`としましたが、notificationsテーブルのreadカラムと名称が被っているのは問題ありますでしょうか？
適切な言葉が思い浮かばなかったため、これにしていますがエンジニアの方々はこういう時にどういった言葉で設定するのでしょうか？

## 実装できなくて後回しにしたところ

## 解決できなかったrubocop指摘

## チェックリスト
- [ ] 動作確認は実行した?

## その他参考情報
- 実装する上で参考にしたサイトなどがあればリンクをここに貼ること
https://qiita.com/ATORA1992/items/566d76a7092bff40df4c
https://qiita.com/hinako_n/items/843bd9227e8b833982ca
https://qiita.com/kcl215/items/c0222befe4a6b270986a

![スクリーンショット 2023-05-09 19 31 21](https://github.com/tatata05/kintai/assets/123435331/662e23e9-08cf-4384-affa-f4ec83c42b31)
![スクリーンショット 2023-05-09 19 31 18](https://github.com/tatata05/kintai/assets/123435331/ff83e260-a1a4-4bf3-b059-f634e9847993)


![スクリーンショット 2023-05-09 19 31 24](https://github.com/tatata05/kintai/assets/123435331/2265de01-cf54-45c7-9a3c-87e360e0b0d0)
