### PR TITLE
定期バッチ処理

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'rails-i18n'
 gem "simple_calendar", "~> 2.4"
 gem 'pry-rails'
 gem 'kaminari'
+gem 'whenever', require: false
 # Use postgresql as the database for Active Record
 gem 'pg', '~> 1.1'
 # Use Puma as the app server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,7 @@ GEM
       sassc-rails (>= 2.0.0)
     builder (3.2.4)
     byebug (11.1.3)
+    chronic (0.10.2)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
@@ -261,6 +262,8 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -292,6 +295,7 @@ DEPENDENCIES
   tzinfo-data
   web-console (>= 4.1.0)
   webpacker (~> 5.0)
+  whenever
 
 RUBY VERSION
    ruby 3.2.1p31

--- a/app/controllers/employee/shifts_controller.rb
+++ b/app/controllers/employee/shifts_controller.rb
@@ -15,6 +15,10 @@ class Employee::ShiftsController < ApplicationController
   def create
     ActiveRecord::Base.transaction do
       @shift = current_employee.shifts.build(shift_params)
+      notification = Notification.find_by(employee_id: current_employee.id, kind: "unapplied")
+      if notification.present? #シフト未申請通知があった場合に、シフトを申請したらその通知を削除する
+        notification.destroy
+      end
       if overlapping_time?
         flash.now[:danger] = "その時間帯はすでにシフトを申請しています"
         return render "new"

--- a/app/controllers/employee/shifts_controller.rb
+++ b/app/controllers/employee/shifts_controller.rb
@@ -16,9 +16,7 @@ class Employee::ShiftsController < ApplicationController
     ActiveRecord::Base.transaction do
       @shift = current_employee.shifts.build(shift_params)
       notification = Notification.find_by(employee_id: current_employee.id, kind: "unapplied")
-      if notification.present? #シフト未申請通知があった場合に、シフトを申請したらその通知を削除する
-        notification.destroy
-      end
+      notification.destroy if notification.present? #シフト未申請通知があった場合に、シフトを申請したらその通知を削除する
       if overlapping_time?
         flash.now[:danger] = "その時間帯はすでにシフトを申請しています"
         return render "new"

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -19,30 +19,32 @@
 
 # Learn more: http://github.com/javan/whenever
 
-# Rails.rootを使用するために必要
-require File.expand_path(File.dirname(__FILE__) + '/environment')
+# 以下は現時点では使用しないためコメントアウト状態,別の方法にて定期バッチ処理を行う。
 
-# cronを実行する環境変数
-rails_env = ENV['RAILS_ENV'] || :development
+# # Rails.rootを使用するために必要
+# require File.expand_path(File.dirname(__FILE__) + '/environment')
 
-# cronを実行する環境変数をセット
-set :environment, rails_env
+# # cronを実行する環境変数
+# rails_env = ENV['RAILS_ENV'] || :development
 
-# cronのログの吐き出し場所
-set :output, "#{Rails.root}/log/cron.log"
+# # cronを実行する環境変数をセット
+# set :environment, rails_env
 
-every 1.day, at: '9:00 am' do
-  rake "shift_check:shift_check_approval_pending"
-end
+# # cronのログの吐き出し場所
+# set :output, "#{Rails.root}/log/cron.log"
 
-every 1.day, at: '9:00 am' do
-  rake "absence_check:absence_check_approval_pending"
-end
+# every 1.day, at: '9:00 am' do
+#   rake "shift_check:shift_check_approval_pending"
+# end
 
-every '0 0 20 * *' do
-  rake "shift_applied_check:shift_applied"
-end
+# every 1.day, at: '9:00 am' do
+#   rake "absence_check:absence_check_approval_pending"
+# end
 
-every 1.month, at: 'start of the month at 0am' do
-  rake "notification_destroy:destroy_unapplied"
-end
+# every '0 0 20 * *' do
+#   rake "shift_applied_check:shift_applied"
+# end
+
+# every 1.month, at: 'start of the month at 0am' do
+#   rake "notification_destroy:destroy_unapplied"
+# end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -31,11 +31,11 @@ set :environment, rails_env
 # cronのログの吐き出し場所
 set :output, "#{Rails.root}/log/cron.log"
 
-every 1.day do
+every 1.day, at: '9:00 am' do
   rake "shift_check:shift_check_approval_pending"
 end
 
-every 1.day do
+every 1.day, at: '9:00 am' do
   rake "absence_check:absence_check_approval_pending"
 end
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,48 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+# Learn more: http://github.com/javan/whenever
+
+# Rails.rootを使用するために必要
+require File.expand_path(File.dirname(__FILE__) + '/environment')
+
+# cronを実行する環境変数
+rails_env = ENV['RAILS_ENV'] || :development
+
+# cronを実行する環境変数をセット
+set :environment, rails_env
+
+# cronのログの吐き出し場所
+set :output, "#{Rails.root}/log/cron.log"
+
+every 1.day do
+  rake "shift_check:shift_check_approval_pending"
+end
+
+every 1.day do
+  rake "absence_check:absence_check_approval_pending"
+end
+
+every '0 0 20 * *' do
+  rake "shift_applied_check:shift_applied"
+end
+
+every 1.month, at: 'start of the month at 0am' do
+  rake "notification_destroy:destroy_unapplied"
+end

--- a/lib/tasks/shift_check.rake
+++ b/lib/tasks/shift_check.rake
@@ -4,7 +4,7 @@ namespace :shift_check do
     time = Time.now
     shifts = Shift.where(status: "unapproved")
     shifts.each do |shift|
-      if shift.created_at.since(5.days) < time && Notification.where(employee_id: shift.employee.id, shift_id: shift.id, kind: "approval_pending").count < 1
+      if shift.created_at.since(5.days) < time
         # 重複したデータを作成させないため、find_or_create_byを使用(if文を使用するより簡潔に記載できる)
         Notification.find_or_create_by(employee_id: shift.employee.id, shift_id: shift.id, kind: "approval_pending")
       end
@@ -18,7 +18,7 @@ namespace :absence_check do
     time = Time.now
     absences = Absence.where(status: "unapproved")
     absences.each do |absence|
-      if absence.created_at.since(1.day) < time && Notification.where(employee_id: absence.shift.employee.id, absence_id: absence.id, kind: "approval_pending").count < 1
+      if absence.created_at.since(1.day) < time
         Notification.find_or_create_by(employee_id: absence.shift.employee.id, absence_id: absence.id, kind: "approval_pending")
       end
     end

--- a/lib/tasks/shift_check.rake
+++ b/lib/tasks/shift_check.rake
@@ -1,10 +1,9 @@
 namespace :shift_check do
   desc "シフト申請がされてから5日以上放置されていた時に通知を行う"
   task shift_check_approval_pending: :environment do
-    time = Time.now
     shifts = Shift.where(status: "unapproved")
     shifts.each do |shift|
-      if shift.created_at.since(5.days) < time
+      if shift.created_at.since(5.days) < Time.now
         # 重複したデータを作成させないため、find_or_create_byを使用(if文を使用するより簡潔に記載できる)
         Notification.find_or_create_by(employee_id: shift.employee.id, shift_id: shift.id, kind: "approval_pending")
       end
@@ -15,10 +14,9 @@ end
 namespace :absence_check do
   desc "欠勤申請がされてから1日以上放置されていた時に通知を行う"
   task absence_check_approval_pending: :environment do
-    time = Time.now
     absences = Absence.where(status: "unapproved")
     absences.each do |absence|
-      if absence.created_at.since(1.day) < time
+      if absence.created_at.since(1.day) < Time.now
         Notification.find_or_create_by(employee_id: absence.shift.employee.id, absence_id: absence.id, kind: "approval_pending")
       end
     end

--- a/lib/tasks/shift_check.rake
+++ b/lib/tasks/shift_check.rake
@@ -29,7 +29,7 @@ namespace :shift_applied_check do
   desc "毎月20日にシフト申請を全くしていない従業員がいた時に通知を行う"
   task shift_applied: :environment do
     employees = Employee.all
-    shifts = Shift.where("start_time > ? and ? > start_time", Date.today.beginning_of_month, Date.today.end_of_month)
+    shifts = Shift.where("start_time > ? and ? > start_time", Date.today.at_beginning_of_month.next_month, Date.today.end_of_month.next_month)
     employees.each do |employee|
       if shifts.where(employee_id: employee.id).count > 0
         Notification.create(employee_id: employee.id, kind: "unapplied")

--- a/lib/tasks/shift_check.rake
+++ b/lib/tasks/shift_check.rake
@@ -1,0 +1,46 @@
+namespace :shift_check do
+  desc "シフト申請がされてから5日以上放置されていた時に通知を行う"
+  task shift_check_approval_pending: :environment do
+    time = Time.now
+    shifts = Shift.where(status: "unapproved")
+    shifts.each do |shift|
+      if shift.created_at.since(5.days) < time && Notification.where(employee_id: shift.employee.id, shift_id: shift.id, kind: "approval_pending").count < 1
+        # 重複したデータを作成させないため、find_or_create_byを使用(if文を使用するより簡潔に記載できる)
+        Notification.find_or_create_by(employee_id: shift.employee.id, shift_id: shift.id, kind: "approval_pending")
+      end
+    end
+  end
+end
+
+namespace :absence_check do
+  desc "欠勤申請がされてから1日以上放置されていた時に通知を行う"
+  task absence_check_approval_pending: :environment do
+    time = Time.now
+    absences = Absence.where(status: "unapproved")
+    absences.each do |absence|
+      if absence.created_at.since(1.day) < time && Notification.where(employee_id: absence.shift.employee.id, absence_id: absence.id, kind: "approval_pending").count < 1
+        Notification.find_or_create_by(employee_id: absence.shift.employee.id, absence_id: absence.id, kind: "approval_pending")
+      end
+    end
+  end
+end
+
+namespace :shift_applied_check do
+  desc "毎月20日にシフト申請を全くしていない従業員がいた時に通知を行う"
+  task shift_applied: :environment do
+    employees = Employee.all
+    shifts = Shift.where("start_time > ? and ? > start_time", Date.today.beginning_of_month, Date.today.end_of_month)
+    employees.each do |employee|
+      if shifts.where(employee_id: employee.id).count > 0
+        Notification.create(employee_id: employee.id, kind: "unapplied")
+      end
+    end
+  end
+end
+
+namespace :notification_destroy do
+  desc "シフト未申請通知が毎月1日に残っていた時に通知を削除する"
+  task destroy_unapplied: :environment do
+    Notification.where(kind: "unapplied").destroy_all
+  end
+end

--- a/lib/tasks/shift_check.rake
+++ b/lib/tasks/shift_check.rake
@@ -27,7 +27,7 @@ namespace :shift_applied_check do
   desc "毎月20日にシフト申請を全くしていない従業員がいた時に通知を行う"
   task shift_applied: :environment do
     employees = Employee.all
-    shifts = Shift.where("start_time > ? and ? > start_time", Date.today.at_beginning_of_month.next_month, Date.today.end_of_month.next_month)
+    shifts = Shift.where(start_time: Time.current.next_month.all_month)
     employees.each do |employee|
       if shifts.where(employee_id: employee.id).count == 0
         Notification.create(employee_id: employee.id, kind: "unapplied")

--- a/lib/tasks/shift_check.rake
+++ b/lib/tasks/shift_check.rake
@@ -3,7 +3,7 @@ namespace :shift_check do
   task shift_check_approval_pending: :environment do
     shifts = Shift.where(status: "unapproved")
     shifts.each do |shift|
-      if shift.created_at.since(5.days) < Time.now
+      if shift.created_at < Time.current.ago(5.days)
         # 重複したデータを作成させないため、find_or_create_byを使用(if文を使用するより簡潔に記載できる)
         Notification.find_or_create_by(employee_id: shift.employee.id, shift_id: shift.id, kind: "approval_pending")
       end
@@ -16,7 +16,7 @@ namespace :absence_check do
   task absence_check_approval_pending: :environment do
     absences = Absence.where(status: "unapproved")
     absences.each do |absence|
-      if absence.created_at.since(1.day) < Time.now
+      if absence.created_at < Time.current.ago(1.days)
         Notification.find_or_create_by(employee_id: absence.shift.employee.id, absence_id: absence.id, kind: "approval_pending")
       end
     end
@@ -29,7 +29,7 @@ namespace :shift_applied_check do
     employees = Employee.all
     shifts = Shift.where("start_time > ? and ? > start_time", Date.today.at_beginning_of_month.next_month, Date.today.end_of_month.next_month)
     employees.each do |employee|
-      if shifts.where(employee_id: employee.id).count > 0
+      if shifts.where(employee_id: employee.id).count == 0
         Notification.create(employee_id: employee.id, kind: "unapplied")
       end
     end


### PR DESCRIPTION
## このプルリクエストで何をしたのか
・シフト申請後、5日が経過しても承認されていないときの未承認通知
・欠勤申請後、１日が経過しても承認されていないときの未承認通知
・毎月20日に、シフトを申請していない従業員がいたときのシフト未申請通知
・毎月1日に、シフト未申請通知の削除

wheneverについては必要ないとお伺いしましたが、すでに作成していた部分があったため、自分自身の辞書的な意味ために残したままにしています。

## 対象issue
- 作業したissueのURLをここに貼ること

## 重点的に見てほしいところ(不安なところ)

`lib/tasks/shift_check.rake`に
 重複したデータを作成させないため、find_or_create_byを使用(if文を使用するより簡潔に記載できる)
と記載させていただきましたが、この方法は問題ないのでしょうか？

## 実装できなくて後回しにしたところ

## 解決できなかったrubocop指摘

## チェックリスト
- [x] 動作確認は実行した?

## その他参考情報
- 実装する上で参考にしたサイトなどがあればリンクをここに貼ること
`rake -T`でrakeタスクの一覧を表示したものを貼り付けます。
![スクリーンショット 2023-05-26 11 24 11](https://github.com/tatata05/kintai/assets/123435331/9e37c0f7-4bdc-42be-8d31-465bb60f9885)

